### PR TITLE
Adds git config vars to customize behavior of git bash completion

### DIFF
--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -363,13 +363,13 @@ __git_refs ()
 			done
 			format="refname:short"
 			refs="refs/heads"
-			[[ $(git config --boolean --get completion.bash.disableTags) = "true" ]] || refs="$refs /refs/tags"
-			[[ $(git config --boolean --get completion.bash.disableRemotes) = "true" ]] || refs="$refs /refs/remotes"
+			[[ $(git config --bool --get completion.bash.disableTags) = "true" ]] || refs="$refs /refs/tags"
+			[[ $(git config --bool --get completion.bash.disableRemotes) = "true" ]] || refs="$refs /refs/remotes"
 			;;
 		esac
 		git --git-dir="$dir" for-each-ref --format="%($format)" \
 			$refs
-		[[ $(git config --boolean --get completion.bash.disableRemoteTracking) = "true" ]] && track=""
+		[[ $(git config --bool --get completion.bash.disableRemoteTracking) = "true" ]] && track=""
 		if [ -n "$track" ]; then
 			# employ the heuristic used by git checkout
 			# Try to find a remote branch that matches the completion word

--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -362,14 +362,14 @@ __git_refs ()
 				if [ -e "$dir/$i" ]; then echo $i; fi
 			done
 			format="refname:short"
-                        refs="refs/heads"
-                        [[ $(git config --boolean --get completion.bash.disableTags) = "true" ]] || refs="$refs /refs/tags"
-                        [[ $(git config --boolean --get completion.bash.disableRemotes) = "true" ]] || refs="$refs /refs/remotes"
+			refs="refs/heads"
+			[[ $(git config --boolean --get completion.bash.disableTags) = "true" ]] || refs="$refs /refs/tags"
+			[[ $(git config --boolean --get completion.bash.disableRemotes) = "true" ]] || refs="$refs /refs/remotes"
 			;;
 		esac
 		git --git-dir="$dir" for-each-ref --format="%($format)" \
 			$refs
-                [[ $(git config --boolean --get completion.bash.disableRemoteTracking) = "true" ]] && track=""
+		[[ $(git config --boolean --get completion.bash.disableRemoteTracking) = "true" ]] && track=""
 		if [ -n "$track" ]; then
 			# employ the heuristic used by git checkout
 			# Try to find a remote branch that matches the completion word

--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -348,12 +348,12 @@ __git_refs ()
 				if [ -e "$dir/$i" ]; then echo $i; fi
 			done
 			format="refname:short"
-			refs="refs/tags refs/heads refs/remotes"
+			refs="${GIT_COMPLETION_REFS_BASE_PATTERNS:-refs/heads refs/tags refs/remotes}"
 			;;
 		esac
 		git --git-dir="$dir" for-each-ref --format="%($format)" \
 			$refs
-		if [ -n "$track" ]; then
+		if [ -z "$GIT_COMPLETION_REFS_DISABLE_TRACKING" -a -n "$track" ]; then
 			# employ the heuristic used by git checkout
 			# Try to find a remote branch that matches the completion word
 			# but only output if the branch name is unique

--- a/contrib/completion/git-completion.bash
+++ b/contrib/completion/git-completion.bash
@@ -21,6 +21,16 @@
 #        source ~/.git-completion.sh
 #    3) Consider changing your PS1 to also show the current branch,
 #       see git-prompt.sh for details.
+#
+# Use the following environment variables modify completion behavior:
+#
+# GIT_COMPLETION_REFS_BASE_PATTERNS -- space delimited set of patterns to use with git
+#   `for-each-ref` to compute ref name completions. Defaults to "refs/heads refs/tags refs/remotes".
+#
+# GIT_COMPLETION_REFS_DISABLE_REMOTE_TRACKING -- if defined, when computing ref name completions do
+#   not attempt to find remote ref names unique across all remotes which match current
+#   prefix. Defaults to undefined.
+#
 
 case "$COMP_WORDBREAKS" in
 *:*) : great ;;
@@ -353,7 +363,7 @@ __git_refs ()
 		esac
 		git --git-dir="$dir" for-each-ref --format="%($format)" \
 			$refs
-		if [ -z "$GIT_COMPLETION_REFS_DISABLE_TRACKING" -a -n "$track" ]; then
+		if [ -z "$GIT_COMPLETION_REFS_DISABLE_REMOTE_TRACKING" -a -n "$track" ]; then
 			# employ the heuristic used by git checkout
 			# Try to find a remote branch that matches the completion word
 			# but only output if the branch name is unique


### PR DESCRIPTION
Due to the high volume of changes in Twitter's _source_ monorepo, the existing behavior of git bash completion is bad: By default, completion of git ref names includes patterns `refs/heads`, `refs/tags`, and `refs/remotes`. As of this writing, patterns `refs/tags` and `refs/remotes` pull in nearly 40,000 ref names in _source_, making completion in common contexts like `git checkout <tab>` unusable.

This diff updates git bash completion of refs to allow customization of behavior via git config variables, as described in doc comment at top of `git-completion.bash` file. With these config variables, completion of ref names can be limited to only `refs/heads`, dramatically increasing the speed of `git checkout <tab>`.
